### PR TITLE
Kevin Lavelle - Sort courses so most recent courses are first

### DIFF
--- a/frontend/src/fixtures/sectionFixtures.js
+++ b/frontend/src/fixtures/sectionFixtures.js
@@ -227,6 +227,141 @@ export const threeSections = [
   },
 ];
 
+export const threeSectionsDifferentQuarters = [
+  {
+    courseInfo: {
+      quarter: "20211",
+      courseId: "ECE       1A -1",
+      title: "COMP ENGR SEMINAR",
+      description:
+        "Introductory seminar to expose students to a broad range of topics in computer   engineering.",
+    },
+    section: {
+      enrollCode: "12583",
+      section: "0100",
+      session: null,
+      classClosed: null,
+      courseCancelled: null,
+      gradingOptionCode: null,
+      enrolledTotal: 84,
+      maxEnroll: 100,
+      secondaryStatus: null,
+      departmentApprovalRequired: false,
+      instructorApprovalRequired: false,
+      restrictionLevel: null,
+      restrictionMajor: "+PRCME+CMPEN",
+      restrictionMajorPass: null,
+      restrictionMinor: null,
+      restrictionMinorPass: null,
+      concurrentCourses: [],
+      timeLocations: [
+        {
+          room: "1930",
+          building: "BUCHN",
+          roomCapacity: "100",
+          days: "M      ",
+          beginTime: "15:00",
+          endTime: "15:50",
+        },
+      ],
+      instructors: [
+        {
+          instructor: "WANG L C",
+          functionCode: "Teaching and in charge",
+        },
+      ],
+    },
+  },
+  {
+    courseInfo: {
+      quarter: "20212",
+      courseId: "ECE       5  -1",
+      title: "INTRO TO ECE",
+      description:
+        "Aims at exposing freshmen students to the different sub-fields within Electrical   and Computer   Engineering. Composed of lectures by different faculty members and a weekly   laboratory based   on projects that are executed using the Arduino environment.",
+    },
+    section: {
+      enrollCode: "12591",
+      section: "0100",
+      session: null,
+      classClosed: null,
+      courseCancelled: null,
+      gradingOptionCode: null,
+      enrolledTotal: 84,
+      maxEnroll: 80,
+      secondaryStatus: "R",
+      departmentApprovalRequired: false,
+      instructorApprovalRequired: false,
+      restrictionLevel: "L",
+      restrictionMajor: "+EE   +CMPEN",
+      restrictionMajorPass: null,
+      restrictionMinor: null,
+      restrictionMinorPass: null,
+      concurrentCourses: [],
+      timeLocations: [
+        {
+          room: "1260",
+          building: "PHELP",
+          roomCapacity: "90",
+          days: "M W    ",
+          beginTime: "15:30",
+          endTime: "16:45",
+        },
+      ],
+      instructors: [
+        {
+          instructor: "HESPANHA J P",
+          functionCode: "Teaching and in charge",
+        },
+      ],
+    },
+  },
+  {
+    courseInfo: {
+      quarter: "20213",
+      courseId: "ECE       5  -1",
+      title: "INTRO TO ECE",
+      description:
+        "Aims at exposing freshmen students to the different sub-fields within Electrical   and Computer   Engineering. Composed of lectures by different faculty members and a weekly   laboratory based   on projects that are executed using the Arduino environment.",
+    },
+    section: {
+      enrollCode: "12609",
+      section: "0101",
+      session: null,
+      classClosed: null,
+      courseCancelled: null,
+      gradingOptionCode: null,
+      enrolledTotal: 21,
+      maxEnroll: 21,
+      secondaryStatus: null,
+      departmentApprovalRequired: false,
+      instructorApprovalRequired: false,
+      restrictionLevel: "L",
+      restrictionMajor: "+EE   +CMPEN",
+      restrictionMajorPass: null,
+      restrictionMinor: null,
+      restrictionMinorPass: null,
+      concurrentCourses: [],
+      timeLocations: [
+        {
+          room: "1124",
+          building: "HFH",
+          roomCapacity: null,
+          days: "    F  ",
+          beginTime: "12:00",
+          endTime: "14:50",
+        },
+      ],
+      instructors: [
+        {
+          instructor: "YUNG A S",
+          functionCode: "Teaching but not in charge",
+        },
+      ],
+    },
+  },
+];
+
 export const fiveSections = [
   {
     courseInfo: {

--- a/frontend/src/main/pages/CourseOverTime/CourseOverTimeIndexPage.js
+++ b/frontend/src/main/pages/CourseOverTime/CourseOverTimeIndexPage.js
@@ -19,7 +19,10 @@ export default function CourseOverTimeIndexPage() {
   });
 
   const onSuccess = (courses) => {
-    setCourseJSON(courses);
+    const sortedCourses = courses.sort((a, b) =>
+      b.courseInfo.quarter.localeCompare(a.courseInfo.quarter),
+    );
+    setCourseJSON(sortedCourses);
   };
 
   const mutation = useBackendMutation(


### PR DESCRIPTION
Here, we added code to sort the course history page and added tests and fixtures to test correct sorting of courses. The courses should now be displayed with the most recent course on the top row. 

Link to issue here: https://github.com/ucsb-cs156-s24/proj-courses-s24-4pm-3/issues/17

Here is what the UCSB Course History Search Page looked like before: 

<img width="1243" alt="PNG image" src="https://github.com/ucsb-cs156-s24/proj-courses-s24-4pm-3/assets/51886555/62cfa829-17b7-4f6a-bf9f-2584d64ddbd9">


Here is what the page looks like with this new code to sort: 

<img width="1293" alt="PNG image" src="https://github.com/ucsb-cs156-s24/proj-courses-s24-4pm-3/assets/51886555/29602f80-bd01-4bba-829c-6d791a5361ce">

Dokku Deployment: https://proj-courses-a-k-u-m-a-r.dokku-03.cs.ucsb.edu
(Please note this Dokku employments contains further commits from further branches containing additional features)
Closes #17 