### PR TITLE
Kevin Lavelle - Changed React App to UCSB Courses App

### DIFF
--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -25,7 +25,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>React App</title>
+    <title>UCSB Courses App</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>


### PR DESCRIPTION
This PR simply changed the tab preview name from "React App" to "UCSB Courses App"
Link to issue: https://github.com/ucsb-cs156-s24/proj-courses-s24-4pm-3/issues/31

Before:
<img width="1342" alt="PNG image" src="https://github.com/ucsb-cs156-s24/proj-courses-s24-4pm-3/assets/51886555/b7bcf300-6ea4-45c8-bc1d-a6653a1c88de">
Notice how at the top left it says "React App"

After:

<img width="1340" alt="PNG image" src="https://github.com/ucsb-cs156-s24/proj-courses-s24-4pm-3/assets/51886555/7e3883e8-51f2-43ff-8a42-4ee030342960">

Notice how at the top left it now says "UCSB Courses App"

Dokku Deployment: https://proj-courses-a-k-u-m-a-r.dokku-03.cs.ucsb.edu
(Please note this Dokku employments contains additional commits from other PRs containing additional features but I wanted to keep this PR clean with only the edits related to this PR).

Closes #31 