### PR TITLE
Kevin Lavelle - Default Quarter

### DIFF
--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -25,7 +25,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>React App</title>
+    <title>UCSB Courses App</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/frontend/src/fixtures/sectionFixtures.js
+++ b/frontend/src/fixtures/sectionFixtures.js
@@ -227,6 +227,141 @@ export const threeSections = [
   },
 ];
 
+export const threeSectionsDifferentQuarters = [
+  {
+    courseInfo: {
+      quarter: "20211",
+      courseId: "ECE       1A -1",
+      title: "COMP ENGR SEMINAR",
+      description:
+        "Introductory seminar to expose students to a broad range of topics in computer   engineering.",
+    },
+    section: {
+      enrollCode: "12583",
+      section: "0100",
+      session: null,
+      classClosed: null,
+      courseCancelled: null,
+      gradingOptionCode: null,
+      enrolledTotal: 84,
+      maxEnroll: 100,
+      secondaryStatus: null,
+      departmentApprovalRequired: false,
+      instructorApprovalRequired: false,
+      restrictionLevel: null,
+      restrictionMajor: "+PRCME+CMPEN",
+      restrictionMajorPass: null,
+      restrictionMinor: null,
+      restrictionMinorPass: null,
+      concurrentCourses: [],
+      timeLocations: [
+        {
+          room: "1930",
+          building: "BUCHN",
+          roomCapacity: "100",
+          days: "M      ",
+          beginTime: "15:00",
+          endTime: "15:50",
+        },
+      ],
+      instructors: [
+        {
+          instructor: "WANG L C",
+          functionCode: "Teaching and in charge",
+        },
+      ],
+    },
+  },
+  {
+    courseInfo: {
+      quarter: "20212",
+      courseId: "ECE       5  -1",
+      title: "INTRO TO ECE",
+      description:
+        "Aims at exposing freshmen students to the different sub-fields within Electrical   and Computer   Engineering. Composed of lectures by different faculty members and a weekly   laboratory based   on projects that are executed using the Arduino environment.",
+    },
+    section: {
+      enrollCode: "12591",
+      section: "0100",
+      session: null,
+      classClosed: null,
+      courseCancelled: null,
+      gradingOptionCode: null,
+      enrolledTotal: 84,
+      maxEnroll: 80,
+      secondaryStatus: "R",
+      departmentApprovalRequired: false,
+      instructorApprovalRequired: false,
+      restrictionLevel: "L",
+      restrictionMajor: "+EE   +CMPEN",
+      restrictionMajorPass: null,
+      restrictionMinor: null,
+      restrictionMinorPass: null,
+      concurrentCourses: [],
+      timeLocations: [
+        {
+          room: "1260",
+          building: "PHELP",
+          roomCapacity: "90",
+          days: "M W    ",
+          beginTime: "15:30",
+          endTime: "16:45",
+        },
+      ],
+      instructors: [
+        {
+          instructor: "HESPANHA J P",
+          functionCode: "Teaching and in charge",
+        },
+      ],
+    },
+  },
+  {
+    courseInfo: {
+      quarter: "20213",
+      courseId: "ECE       5  -1",
+      title: "INTRO TO ECE",
+      description:
+        "Aims at exposing freshmen students to the different sub-fields within Electrical   and Computer   Engineering. Composed of lectures by different faculty members and a weekly   laboratory based   on projects that are executed using the Arduino environment.",
+    },
+    section: {
+      enrollCode: "12609",
+      section: "0101",
+      session: null,
+      classClosed: null,
+      courseCancelled: null,
+      gradingOptionCode: null,
+      enrolledTotal: 21,
+      maxEnroll: 21,
+      secondaryStatus: null,
+      departmentApprovalRequired: false,
+      instructorApprovalRequired: false,
+      restrictionLevel: "L",
+      restrictionMajor: "+EE   +CMPEN",
+      restrictionMajorPass: null,
+      restrictionMinor: null,
+      restrictionMinorPass: null,
+      concurrentCourses: [],
+      timeLocations: [
+        {
+          room: "1124",
+          building: "HFH",
+          roomCapacity: null,
+          days: "    F  ",
+          beginTime: "12:00",
+          endTime: "14:50",
+        },
+      ],
+      instructors: [
+        {
+          instructor: "YUNG A S",
+          functionCode: "Teaching but not in charge",
+        },
+      ],
+    },
+  },
+];
+
 export const fiveSections = [
   {
     courseInfo: {

--- a/frontend/src/main/components/Nav/AppNavbar.js
+++ b/frontend/src/main/components/Nav/AppNavbar.js
@@ -24,12 +24,14 @@ export default function AppNavbar({
         data-testid="AppNavbar"
       >
         <Container>
-          <img
-            data-testid="AppNavbarImage"
-            src={headerImg}
-            alt=""
-            style={{ width: 80, height: 80, marginRight: 10 }}
-          />
+          <Link to="/">
+            <img
+              data-testid="AppNavbarImage"
+              src={headerImg}
+              alt=""
+              style={{ width: 80, height: 80, marginRight: 10 }}
+            />
+          </Link>
           <Navbar.Brand as={Link} to="/">
             UCSB Courses Search
           </Navbar.Brand>

--- a/frontend/src/main/components/Quarters/SingleQuarterDropdown.js
+++ b/frontend/src/main/components/Quarters/SingleQuarterDropdown.js
@@ -23,7 +23,7 @@ function SingleQuarterDropdown({
 }) {
   const localSearchQuarter = localStorage.getItem(controlId);
   if (!localSearchQuarter) {
-    localStorage.setItem(controlId, quarters[0].yyyyq);
+    localStorage.setItem(controlId, quarters[quarters.length - 1].yyyyq);
   }
 
   const [quarterState, setQuarterState] = useState(

--- a/frontend/src/main/pages/CourseOverTime/CourseOverTimeIndexPage.js
+++ b/frontend/src/main/pages/CourseOverTime/CourseOverTimeIndexPage.js
@@ -19,7 +19,10 @@ export default function CourseOverTimeIndexPage() {
   });
 
   const onSuccess = (courses) => {
-    setCourseJSON(courses);
+    const sortedCourses = courses.sort((a, b) =>
+      b.courseInfo.quarter.localeCompare(a.courseInfo.quarter),
+    );
+    setCourseJSON(sortedCourses);
   };
 
   const mutation = useBackendMutation(


### PR DESCRIPTION
This issue changed the SingleQuarterDropdown component to use the END_QTR rather than START_QTR value. Now when users load into the webpage or reset their local storage, the default search quarter should be the end quarter. 
Issue link: #30 

Here's an example on my localhost with 
START_QTR=20161
END_QTR=20234

<img width="1297" alt="Screenshot 2024-05-25 at 7 43 21 PM" src="https://github.com/ucsb-cs156-s24/proj-courses-s24-4pm-3/assets/51886555/878ff277-9b71-4e29-9266-60667026a6c4">

Dokku Deployment: https://proj-courses-a-k-u-m-a-r.dokku-03.cs.ucsb.edu/
(Please note this Dokku employments contains additional commits from other PRs containing additional features but I wanted to keep this PR clean with only the edits related to this PR).
Dokku config env variables: START_QTR: 20234, END_QTR: 20243


Closes #30 
