### PR TITLE
Kevin Lavelle - Default quarter modified

### DIFF
--- a/frontend/src/main/components/Quarters/SingleQuarterDropdown.js
+++ b/frontend/src/main/components/Quarters/SingleQuarterDropdown.js
@@ -28,7 +28,7 @@ function SingleQuarterDropdown({
 
   const [quarterState, setQuarterState] = useState(
     // Stryker disable next-line all : not sure how to test/mock local storage
-    quarter.yyyq || localSearchQuarter || quarters[0].yyyyq,
+    quarter.yyyq || localSearchQuarter || quarters[quarters.length - 1].yyyyq,
   );
 
   const handleQuarterOnChange = (event) => {

--- a/frontend/src/main/components/Quarters/SingleQuarterDropdown.js
+++ b/frontend/src/main/components/Quarters/SingleQuarterDropdown.js
@@ -23,7 +23,7 @@ function SingleQuarterDropdown({
 }) {
   const localSearchQuarter = localStorage.getItem(controlId);
   if (!localSearchQuarter) {
-    localStorage.setItem(controlId, quarters[0].yyyyq);
+    localStorage.setItem(controlId, quarters[quarters.length - 1].yyyyq);
   }
 
   const [quarterState, setQuarterState] = useState(

--- a/frontend/src/tests/components/Quarters/SingleQuarterDropdown.test.js
+++ b/frontend/src/tests/components/Quarters/SingleQuarterDropdown.test.js
@@ -146,7 +146,7 @@ describe("SingleQuarterSelector tests", () => {
       />,
     );
 
-    await waitFor(() => expect(useState).toBeCalledWith("20201"));
+    await waitFor(() => expect(useState).toBeCalledWith("20224"));
   });
 
   test("when localstorage has no value, last element of quarter range is the default parameter", async () => {

--- a/frontend/src/tests/components/Quarters/SingleQuarterDropdown.test.js
+++ b/frontend/src/tests/components/Quarters/SingleQuarterDropdown.test.js
@@ -149,7 +149,7 @@ describe("SingleQuarterSelector tests", () => {
     await waitFor(() => expect(useState).toBeCalledWith("20201"));
   });
 
-  test("when localstorage has no value, first element of quarter range is the default parameter", async () => {
+  test("when localstorage has no value, last element of quarter range is the default parameter", async () => {
     const getItemSpy = jest.spyOn(Storage.prototype, "getItem");
     getItemSpy.mockImplementation(() => null);
 
@@ -165,7 +165,7 @@ describe("SingleQuarterSelector tests", () => {
     );
 
     await waitFor(() =>
-      expect(setQuarterStateSpy).toBeCalledWith("sqd1", "20201"),
+      expect(setQuarterStateSpy).toBeCalledWith("sqd1", "20224"),
     );
   });
 });

--- a/frontend/src/tests/components/Quarters/SingleQuarterDropdown.test.js
+++ b/frontend/src/tests/components/Quarters/SingleQuarterDropdown.test.js
@@ -130,7 +130,7 @@ describe("SingleQuarterSelector tests", () => {
     await waitFor(() => expect(useState).toBeCalledWith("20202"));
   });
 
-  test("when localstorage has no value, first element of quarter range is passed to useState", async () => {
+  test("when localstorage has no value, last element of quarter range is passed to useState", async () => {
     const getItemSpy = jest.spyOn(Storage.prototype, "getItem");
     getItemSpy.mockImplementation(() => null);
 


### PR DESCRIPTION
This issue changed the SingleQuarterDropdown component to use the END_QTR rather than START_QTR value. Now when users reset their local storage, the default search quarter should be the end quarter. 
Issue link: #30 

Note: Please clear local storage before attempting

Here's an example on my localhost with 
START_QTR=20161
END_QTR=20234

<img width="1297" alt="Screenshot 2024-05-25 at 7 43 21 PM" src="https://github.com/ucsb-cs156-s24/proj-courses-s24-4pm-3/assets/51886555/878ff277-9b71-4e29-9266-60667026a6c4">

Dokku Deployment: https://proj-courses-a-k-u-m-a-r.dokku-03.cs.ucsb.edu/
(Please note this Dokku employments contains additional commits from other PRs containing additional features but I wanted to keep this PR clean with only the edits related to this PR).
Dokku config env variables: START_QTR: 20234, END_QTR: 20243


Closes #30 
