### PR TITLE
Kevin Lavelle -Easier Search 

### DIFF
--- a/frontend/src/main/components/BasicCourseSearch/CourseOverTimeSearchForm.js
+++ b/frontend/src/main/components/BasicCourseSearch/CourseOverTimeSearchForm.js
@@ -70,17 +70,17 @@ const CourseOverTimeSearchForm = ({ fetchJSON }) => {
 
   const handleCourseNumberOnChange = (event) => {
     const rawCourse = event.target.value;
-    if (rawCourse.match(/\d+/g) != null) {
-      const number = rawCourse.match(/\d+/g)[0];
+    const firstDigitIndex = rawCourse.search(/\d/);
+    if (firstDigitIndex !== -1) {
+      const strippedCourse = rawCourse.slice(firstDigitIndex);
+      const numberMatch = strippedCourse.match(/\d+/g);
+      const suffixMatch = strippedCourse.match(/[a-zA-Z]+/g);
+      const number = numberMatch ? numberMatch[0] : "";
+      const suffix = suffixMatch ? suffixMatch[0] : "";
       setCourseNumber(number);
-    } else {
-      setCourseNumber("");
-    }
-
-    if (rawCourse.match(/[a-zA-Z]+/g) != null) {
-      const suffix = rawCourse.match(/[a-zA-Z]+/g)[0];
       setCourseSuf(suffix);
     } else {
+      setCourseNumber("");
       setCourseSuf("");
     }
   };

--- a/frontend/src/main/components/BasicCourseSearch/CourseOverTimeSearchForm.js
+++ b/frontend/src/main/components/BasicCourseSearch/CourseOverTimeSearchForm.js
@@ -74,12 +74,12 @@ const CourseOverTimeSearchForm = ({ fetchJSON }) => {
 
     if (firstDigitIndex !== -1) {
       const strippedCourse = rawCourse.slice(firstDigitIndex);
-      const numberMatch = strippedCourse.match(/\d+/g);
+      //const numberMatch = strippedCourse.match(/\d+/g);
       const suffixMatch = strippedCourse.match(/[a-zA-Z]+/g);
 
       let number = "";
-      if (numberMatch) {
-        number = numberMatch[0];
+      if (strippedCourse.match(/\d+/g)) {
+        number = strippedCourse.match(/\d+/g)[0];
       }
 
       let suffix = "";

--- a/frontend/src/main/components/BasicCourseSearch/CourseOverTimeSearchForm.js
+++ b/frontend/src/main/components/BasicCourseSearch/CourseOverTimeSearchForm.js
@@ -71,12 +71,22 @@ const CourseOverTimeSearchForm = ({ fetchJSON }) => {
   const handleCourseNumberOnChange = (event) => {
     const rawCourse = event.target.value;
     const firstDigitIndex = rawCourse.search(/\d/);
+    
     if (firstDigitIndex !== -1) {
       const strippedCourse = rawCourse.slice(firstDigitIndex);
       const numberMatch = strippedCourse.match(/\d+/g);
       const suffixMatch = strippedCourse.match(/[a-zA-Z]+/g);
-      const number = numberMatch ? numberMatch[0] : "";
-      const suffix = suffixMatch ? suffixMatch[0] : "";
+      
+      let number = "";
+      if (numberMatch) {
+        number = numberMatch[0];
+      }
+  
+      let suffix = "";
+      if (suffixMatch) {
+        suffix = suffixMatch[0];
+      }
+  
       setCourseNumber(number);
       setCourseSuf(suffix);
     } else {
@@ -84,6 +94,7 @@ const CourseOverTimeSearchForm = ({ fetchJSON }) => {
       setCourseSuf("");
     }
   };
+  
 
   // Stryker disable all : Stryker is testing by changing the padding to 0. But this is simply a visual optimization as it makes it look better
   return (

--- a/frontend/src/main/components/BasicCourseSearch/CourseOverTimeSearchForm.js
+++ b/frontend/src/main/components/BasicCourseSearch/CourseOverTimeSearchForm.js
@@ -71,22 +71,12 @@ const CourseOverTimeSearchForm = ({ fetchJSON }) => {
   const handleCourseNumberOnChange = (event) => {
     const rawCourse = event.target.value;
     const firstDigitIndex = rawCourse.search(/\d/);
-
     if (firstDigitIndex !== -1) {
       const strippedCourse = rawCourse.slice(firstDigitIndex);
-      //const numberMatch = strippedCourse.match(/\d+/g);
+      const numberMatch = strippedCourse.match(/\d+/g);
       const suffixMatch = strippedCourse.match(/[a-zA-Z]+/g);
-
-      let number = "";
-      if (strippedCourse.match(/\d+/g)) {
-        number = strippedCourse.match(/\d+/g)[0];
-      }
-
-      let suffix = "";
-      if (suffixMatch) {
-        suffix = suffixMatch[0];
-      }
-
+      const number = numberMatch[0];
+      const suffix = suffixMatch ? suffixMatch[0] : "";
       setCourseNumber(number);
       setCourseSuf(suffix);
     } else {

--- a/frontend/src/main/components/BasicCourseSearch/CourseOverTimeSearchForm.js
+++ b/frontend/src/main/components/BasicCourseSearch/CourseOverTimeSearchForm.js
@@ -71,22 +71,22 @@ const CourseOverTimeSearchForm = ({ fetchJSON }) => {
   const handleCourseNumberOnChange = (event) => {
     const rawCourse = event.target.value;
     const firstDigitIndex = rawCourse.search(/\d/);
-    
+
     if (firstDigitIndex !== -1) {
       const strippedCourse = rawCourse.slice(firstDigitIndex);
       const numberMatch = strippedCourse.match(/\d+/g);
       const suffixMatch = strippedCourse.match(/[a-zA-Z]+/g);
-      
+
       let number = "";
       if (numberMatch) {
         number = numberMatch[0];
       }
-  
+
       let suffix = "";
       if (suffixMatch) {
         suffix = suffixMatch[0];
       }
-  
+
       setCourseNumber(number);
       setCourseSuf(suffix);
     } else {
@@ -94,7 +94,6 @@ const CourseOverTimeSearchForm = ({ fetchJSON }) => {
       setCourseSuf("");
     }
   };
-  
 
   // Stryker disable all : Stryker is testing by changing the padding to 0. But this is simply a visual optimization as it makes it look better
   return (

--- a/frontend/src/tests/components/BasicCourseSearch/CourseOverTimeSearchForm.test.js
+++ b/frontend/src/tests/components/BasicCourseSearch/CourseOverTimeSearchForm.test.js
@@ -145,6 +145,57 @@ describe("CourseOverTimeSearchForm tests", () => {
     expect(selectCourseNumber.value).toBe("A");
   });
 
+  test("when a course number with letters before numbers is typed and the form is submitted, the state updates correctly", async () => {
+    axiosMock.onGet("/api/UCSBSubjects/all").reply(200, allTheSubjects);
+    const sampleReturnValue = {
+      sampleKey: "sampleValue",
+    };
+
+    const fetchJSONSpy = jest.fn();
+    fetchJSONSpy.mockResolvedValue(sampleReturnValue);
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <CourseOverTimeSearchForm fetchJSON={fetchJSONSpy} />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    const expectedFields = {
+      startQuarter: "20211",
+      endQuarter: "20214",
+      subject: "CMPSC",
+      courseNumber: "130",
+      courseSuf: "A",
+    };
+
+    const expectedKey = "CourseOverTimeSearch.Subject-option-CMPSC";
+    await waitFor(() =>
+      expect(screen.getByTestId(expectedKey)).toBeInTheDocument(),
+    );
+
+    const selectStartQuarter = screen.getByLabelText("Start Quarter");
+    userEvent.selectOptions(selectStartQuarter, "20211");
+    const selectEndQuarter = screen.getByLabelText("End Quarter");
+    userEvent.selectOptions(selectEndQuarter, "20214");
+    const selectSubject = screen.getByLabelText("Subject Area");
+    userEvent.selectOptions(selectSubject, "CMPSC");
+    const selectCourseNumber = screen.getByLabelText(
+      "Course Number (Try searching '16' or '130A')",
+    );
+    userEvent.type(selectCourseNumber, "CS130A");
+    const submitButton = screen.getByText("Submit");
+    userEvent.click(submitButton);
+
+    await waitFor(() => expect(fetchJSONSpy).toHaveBeenCalledTimes(1));
+
+    expect(fetchJSONSpy).toHaveBeenCalledWith(
+      expect.any(Object),
+      expectedFields,
+    );
+  });
+
   test("when I click submit, the right stuff happens", async () => {
     axiosMock.onGet("/api/UCSBSubjects/all").reply(200, allTheSubjects);
     const sampleReturnValue = {

--- a/frontend/src/tests/components/BasicCourseSearch/CourseOverTimeSearchForm.test.js
+++ b/frontend/src/tests/components/BasicCourseSearch/CourseOverTimeSearchForm.test.js
@@ -150,10 +150,10 @@ describe("CourseOverTimeSearchForm tests", () => {
     const sampleReturnValue = {
       sampleKey: "sampleValue",
     };
-  
+
     const fetchJSONSpy = jest.fn();
     fetchJSONSpy.mockResolvedValue(sampleReturnValue);
-  
+
     render(
       <QueryClientProvider client={queryClient}>
         <MemoryRouter>
@@ -161,7 +161,7 @@ describe("CourseOverTimeSearchForm tests", () => {
         </MemoryRouter>
       </QueryClientProvider>,
     );
-  
+
     const expectedFields = {
       startQuarter: "20211",
       endQuarter: "20214",
@@ -169,12 +169,10 @@ describe("CourseOverTimeSearchForm tests", () => {
       courseNumber: "130",
       courseSuf: "A",
     };
-  
+
     const expectedKey = "CourseOverTimeSearch.Subject-option-CMPSC";
-    await waitFor(() =>
-      expect(screen.getByTestId(expectedKey)).toBeInTheDocument(),
-    );
-  
+    await screen.findByTestId(expectedKey);
+
     const selectStartQuarter = screen.getByLabelText("Start Quarter");
     userEvent.selectOptions(selectStartQuarter, "20211");
     const selectEndQuarter = screen.getByLabelText("End Quarter");
@@ -187,24 +185,24 @@ describe("CourseOverTimeSearchForm tests", () => {
     userEvent.type(selectCourseNumber, "CS130A");
     const submitButton = screen.getByText("Submit");
     userEvent.click(submitButton);
-  
+
     await waitFor(() => expect(fetchJSONSpy).toHaveBeenCalledTimes(1));
-  
+
     expect(fetchJSONSpy).toHaveBeenCalledWith(
       expect.any(Object),
       expectedFields,
     );
-  });  
+  });
 
   test("when a course number with letters before numbers and does not have a suffix is typed and the form is submitted, the state updates correctly", async () => {
     axiosMock.onGet("/api/UCSBSubjects/all").reply(200, allTheSubjects);
     const sampleReturnValue = {
       sampleKey: "sampleValue",
     };
-  
+
     const fetchJSONSpy = jest.fn();
     fetchJSONSpy.mockResolvedValue(sampleReturnValue);
-  
+
     render(
       <QueryClientProvider client={queryClient}>
         <MemoryRouter>
@@ -212,7 +210,7 @@ describe("CourseOverTimeSearchForm tests", () => {
         </MemoryRouter>
       </QueryClientProvider>,
     );
-  
+
     const expectedFields = {
       startQuarter: "20211",
       endQuarter: "20214",
@@ -220,12 +218,10 @@ describe("CourseOverTimeSearchForm tests", () => {
       courseNumber: "64",
       courseSuf: "",
     };
-  
+
     const expectedKey = "CourseOverTimeSearch.Subject-option-CMPSC";
-    await waitFor(() =>
-      expect(screen.getByTestId(expectedKey)).toBeInTheDocument(),
-    );
-  
+    await screen.findByTestId(expectedKey);
+
     const selectStartQuarter = screen.getByLabelText("Start Quarter");
     userEvent.selectOptions(selectStartQuarter, "20211");
     const selectEndQuarter = screen.getByLabelText("End Quarter");
@@ -238,14 +234,14 @@ describe("CourseOverTimeSearchForm tests", () => {
     userEvent.type(selectCourseNumber, "CS64");
     const submitButton = screen.getByText("Submit");
     userEvent.click(submitButton);
-  
+
     await waitFor(() => expect(fetchJSONSpy).toHaveBeenCalledTimes(1));
-  
+
     expect(fetchJSONSpy).toHaveBeenCalledWith(
       expect.any(Object),
       expectedFields,
     );
-  });  
+  });
 
   test("when I click submit, the right stuff happens", async () => {
     axiosMock.onGet("/api/UCSBSubjects/all").reply(200, allTheSubjects);

--- a/frontend/src/tests/components/BasicCourseSearch/CourseOverTimeSearchForm.test.js
+++ b/frontend/src/tests/components/BasicCourseSearch/CourseOverTimeSearchForm.test.js
@@ -248,10 +248,10 @@ describe("CourseOverTimeSearchForm tests", () => {
     const sampleReturnValue = {
       sampleKey: "sampleValue",
     };
-  
+
     const fetchJSONSpy = jest.fn();
     fetchJSONSpy.mockResolvedValue(sampleReturnValue);
-  
+
     render(
       <QueryClientProvider client={queryClient}>
         <MemoryRouter>
@@ -259,7 +259,7 @@ describe("CourseOverTimeSearchForm tests", () => {
         </MemoryRouter>
       </QueryClientProvider>,
     );
-  
+
     const expectedFields = {
       startQuarter: "20211",
       endQuarter: "20214",
@@ -267,10 +267,10 @@ describe("CourseOverTimeSearchForm tests", () => {
       courseNumber: "130",
       courseSuf: "",
     };
-  
+
     const expectedKey = "CourseOverTimeSearch.Subject-option-CMPSC";
-    await screen.findByTestId(expectedKey);  // Replaces the waitFor + getByTestId
-  
+    await screen.findByTestId(expectedKey); // Replaces the waitFor + getByTestId
+
     const selectStartQuarter = screen.getByLabelText("Start Quarter");
     userEvent.selectOptions(selectStartQuarter, "20211");
     const selectEndQuarter = screen.getByLabelText("End Quarter");
@@ -283,24 +283,24 @@ describe("CourseOverTimeSearchForm tests", () => {
     userEvent.type(selectCourseNumber, "CS130");
     const submitButton = screen.getByText("Submit");
     userEvent.click(submitButton);
-  
+
     await waitFor(() => expect(fetchJSONSpy).toHaveBeenCalledTimes(1));
-  
+
     expect(fetchJSONSpy).toHaveBeenCalledWith(
       expect.any(Object),
       expectedFields,
     );
   });
-  
+
   test("when a course number with no digits is typed, the state is updated correctly", async () => {
     axiosMock.onGet("/api/UCSBSubjects/all").reply(200, allTheSubjects);
     const sampleReturnValue = {
       sampleKey: "sampleValue",
     };
-  
+
     const fetchJSONSpy = jest.fn();
     fetchJSONSpy.mockResolvedValue(sampleReturnValue);
-  
+
     render(
       <QueryClientProvider client={queryClient}>
         <MemoryRouter>
@@ -308,7 +308,7 @@ describe("CourseOverTimeSearchForm tests", () => {
         </MemoryRouter>
       </QueryClientProvider>,
     );
-  
+
     const expectedFields = {
       startQuarter: "20211",
       endQuarter: "20214",
@@ -316,10 +316,10 @@ describe("CourseOverTimeSearchForm tests", () => {
       courseNumber: "",
       courseSuf: "",
     };
-  
+
     const expectedKey = "CourseOverTimeSearch.Subject-option-CMPSC";
-    await screen.findByTestId(expectedKey);  // Replaces the waitFor + getByTestId
-  
+    await screen.findByTestId(expectedKey); // Replaces the waitFor + getByTestId
+
     const selectStartQuarter = screen.getByLabelText("Start Quarter");
     userEvent.selectOptions(selectStartQuarter, "20211");
     const selectEndQuarter = screen.getByLabelText("End Quarter");
@@ -332,9 +332,9 @@ describe("CourseOverTimeSearchForm tests", () => {
     userEvent.type(selectCourseNumber, "CSABC");
     const submitButton = screen.getByText("Submit");
     userEvent.click(submitButton);
-  
+
     await waitFor(() => expect(fetchJSONSpy).toHaveBeenCalledTimes(1));
-  
+
     expect(fetchJSONSpy).toHaveBeenCalledWith(
       expect.any(Object),
       expectedFields,

--- a/frontend/src/tests/components/BasicCourseSearch/CourseOverTimeSearchForm.test.js
+++ b/frontend/src/tests/components/BasicCourseSearch/CourseOverTimeSearchForm.test.js
@@ -243,6 +243,104 @@ describe("CourseOverTimeSearchForm tests", () => {
     );
   });
 
+  test("when a course number with no suffix is typed and the form is submitted, the state updates correctly", async () => {
+    axiosMock.onGet("/api/UCSBSubjects/all").reply(200, allTheSubjects);
+    const sampleReturnValue = {
+      sampleKey: "sampleValue",
+    };
+  
+    const fetchJSONSpy = jest.fn();
+    fetchJSONSpy.mockResolvedValue(sampleReturnValue);
+  
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <CourseOverTimeSearchForm fetchJSON={fetchJSONSpy} />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+  
+    const expectedFields = {
+      startQuarter: "20211",
+      endQuarter: "20214",
+      subject: "CMPSC",
+      courseNumber: "130",
+      courseSuf: "",
+    };
+  
+    const expectedKey = "CourseOverTimeSearch.Subject-option-CMPSC";
+    await screen.findByTestId(expectedKey);  // Replaces the waitFor + getByTestId
+  
+    const selectStartQuarter = screen.getByLabelText("Start Quarter");
+    userEvent.selectOptions(selectStartQuarter, "20211");
+    const selectEndQuarter = screen.getByLabelText("End Quarter");
+    userEvent.selectOptions(selectEndQuarter, "20214");
+    const selectSubject = screen.getByLabelText("Subject Area");
+    userEvent.selectOptions(selectSubject, "CMPSC");
+    const selectCourseNumber = screen.getByLabelText(
+      "Course Number (Try searching '16' or '130A')",
+    );
+    userEvent.type(selectCourseNumber, "CS130");
+    const submitButton = screen.getByText("Submit");
+    userEvent.click(submitButton);
+  
+    await waitFor(() => expect(fetchJSONSpy).toHaveBeenCalledTimes(1));
+  
+    expect(fetchJSONSpy).toHaveBeenCalledWith(
+      expect.any(Object),
+      expectedFields,
+    );
+  });
+  
+  test("when a course number with no digits is typed, the state is updated correctly", async () => {
+    axiosMock.onGet("/api/UCSBSubjects/all").reply(200, allTheSubjects);
+    const sampleReturnValue = {
+      sampleKey: "sampleValue",
+    };
+  
+    const fetchJSONSpy = jest.fn();
+    fetchJSONSpy.mockResolvedValue(sampleReturnValue);
+  
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <CourseOverTimeSearchForm fetchJSON={fetchJSONSpy} />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+  
+    const expectedFields = {
+      startQuarter: "20211",
+      endQuarter: "20214",
+      subject: "CMPSC",
+      courseNumber: "",
+      courseSuf: "",
+    };
+  
+    const expectedKey = "CourseOverTimeSearch.Subject-option-CMPSC";
+    await screen.findByTestId(expectedKey);  // Replaces the waitFor + getByTestId
+  
+    const selectStartQuarter = screen.getByLabelText("Start Quarter");
+    userEvent.selectOptions(selectStartQuarter, "20211");
+    const selectEndQuarter = screen.getByLabelText("End Quarter");
+    userEvent.selectOptions(selectEndQuarter, "20214");
+    const selectSubject = screen.getByLabelText("Subject Area");
+    userEvent.selectOptions(selectSubject, "CMPSC");
+    const selectCourseNumber = screen.getByLabelText(
+      "Course Number (Try searching '16' or '130A')",
+    );
+    userEvent.type(selectCourseNumber, "CSABC");
+    const submitButton = screen.getByText("Submit");
+    userEvent.click(submitButton);
+  
+    await waitFor(() => expect(fetchJSONSpy).toHaveBeenCalledTimes(1));
+  
+    expect(fetchJSONSpy).toHaveBeenCalledWith(
+      expect.any(Object),
+      expectedFields,
+    );
+  });
+
   test("when I click submit, the right stuff happens", async () => {
     axiosMock.onGet("/api/UCSBSubjects/all").reply(200, allTheSubjects);
     const sampleReturnValue = {

--- a/frontend/src/tests/components/BasicCourseSearch/CourseOverTimeSearchForm.test.js
+++ b/frontend/src/tests/components/BasicCourseSearch/CourseOverTimeSearchForm.test.js
@@ -150,10 +150,10 @@ describe("CourseOverTimeSearchForm tests", () => {
     const sampleReturnValue = {
       sampleKey: "sampleValue",
     };
-
+  
     const fetchJSONSpy = jest.fn();
     fetchJSONSpy.mockResolvedValue(sampleReturnValue);
-
+  
     render(
       <QueryClientProvider client={queryClient}>
         <MemoryRouter>
@@ -161,7 +161,7 @@ describe("CourseOverTimeSearchForm tests", () => {
         </MemoryRouter>
       </QueryClientProvider>,
     );
-
+  
     const expectedFields = {
       startQuarter: "20211",
       endQuarter: "20214",
@@ -169,12 +169,12 @@ describe("CourseOverTimeSearchForm tests", () => {
       courseNumber: "130",
       courseSuf: "A",
     };
-
+  
     const expectedKey = "CourseOverTimeSearch.Subject-option-CMPSC";
     await waitFor(() =>
       expect(screen.getByTestId(expectedKey)).toBeInTheDocument(),
     );
-
+  
     const selectStartQuarter = screen.getByLabelText("Start Quarter");
     userEvent.selectOptions(selectStartQuarter, "20211");
     const selectEndQuarter = screen.getByLabelText("End Quarter");
@@ -187,14 +187,14 @@ describe("CourseOverTimeSearchForm tests", () => {
     userEvent.type(selectCourseNumber, "CS130A");
     const submitButton = screen.getByText("Submit");
     userEvent.click(submitButton);
-
+  
     await waitFor(() => expect(fetchJSONSpy).toHaveBeenCalledTimes(1));
-
+  
     expect(fetchJSONSpy).toHaveBeenCalledWith(
       expect.any(Object),
       expectedFields,
     );
-  });
+  });  
 
   test("when I click submit, the right stuff happens", async () => {
     axiosMock.onGet("/api/UCSBSubjects/all").reply(200, allTheSubjects);

--- a/frontend/src/tests/components/BasicCourseSearch/CourseOverTimeSearchForm.test.js
+++ b/frontend/src/tests/components/BasicCourseSearch/CourseOverTimeSearchForm.test.js
@@ -196,6 +196,57 @@ describe("CourseOverTimeSearchForm tests", () => {
     );
   });  
 
+  test("when a course number with letters before numbers and does not have a suffix is typed and the form is submitted, the state updates correctly", async () => {
+    axiosMock.onGet("/api/UCSBSubjects/all").reply(200, allTheSubjects);
+    const sampleReturnValue = {
+      sampleKey: "sampleValue",
+    };
+  
+    const fetchJSONSpy = jest.fn();
+    fetchJSONSpy.mockResolvedValue(sampleReturnValue);
+  
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <CourseOverTimeSearchForm fetchJSON={fetchJSONSpy} />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+  
+    const expectedFields = {
+      startQuarter: "20211",
+      endQuarter: "20214",
+      subject: "CMPSC",
+      courseNumber: "64",
+      courseSuf: "",
+    };
+  
+    const expectedKey = "CourseOverTimeSearch.Subject-option-CMPSC";
+    await waitFor(() =>
+      expect(screen.getByTestId(expectedKey)).toBeInTheDocument(),
+    );
+  
+    const selectStartQuarter = screen.getByLabelText("Start Quarter");
+    userEvent.selectOptions(selectStartQuarter, "20211");
+    const selectEndQuarter = screen.getByLabelText("End Quarter");
+    userEvent.selectOptions(selectEndQuarter, "20214");
+    const selectSubject = screen.getByLabelText("Subject Area");
+    userEvent.selectOptions(selectSubject, "CMPSC");
+    const selectCourseNumber = screen.getByLabelText(
+      "Course Number (Try searching '16' or '130A')",
+    );
+    userEvent.type(selectCourseNumber, "CS64");
+    const submitButton = screen.getByText("Submit");
+    userEvent.click(submitButton);
+  
+    await waitFor(() => expect(fetchJSONSpy).toHaveBeenCalledTimes(1));
+  
+    expect(fetchJSONSpy).toHaveBeenCalledWith(
+      expect.any(Object),
+      expectedFields,
+    );
+  });  
+
   test("when I click submit, the right stuff happens", async () => {
     axiosMock.onGet("/api/UCSBSubjects/all").reply(200, allTheSubjects);
     const sampleReturnValue = {


### PR DESCRIPTION
Users should now be able to search for courses using the course number or with an abbreviation in front. For example, CS130A and 130A would both return the same thing. Note, CS 130A, 130A, and ANTH130A should all return the same course if CMPSC is selected, based on my interpretation of the instructions outlined in #18 
Issue Link: #18 

<img width="1288" alt="Screenshot 2024-05-25 at 9 12 16 PM" src="https://github.com/ucsb-cs156-s24/proj-courses-s24-4pm-3/assets/51886555/943b3bbd-3575-4b55-880f-139264bc3d33">

Dokku Deployment: https://proj-courses-a-k-u-m-a-r.dokku-03.cs.ucsb.edu/
(Please note this Dokku employments contains additional commits from other PRs containing additional features but I wanted to keep this PR clean with only the edits related to this PR).

Closes #18 