### PR TITLE
FEATURE: Swagger option on NavBar

### DIFF
--- a/src/main/resources/application-development.properties
+++ b/src/main/resources/application-development.properties
@@ -5,7 +5,7 @@ spring.datasource.username=sa
 spring.datasource.password=password
 spring.h2.console.settings.web-allow-others=true
 spring.h2.console.enabled=true
-app.showSwaggerUILink=true
+app.showSwaggerUILink=${SHOW_SWAGGER_UI_LINK:${env.SHOW_SWAGGER_UI_LINK:true}}
 
 
 spring.jpa.database-platform=org.hibernate.dialect.H2Dialect

--- a/src/main/resources/application-production.properties
+++ b/src/main/resources/application-production.properties
@@ -1,5 +1,6 @@
 spring.datasource.url=${JDBC_DATABASE_URL}
 spring.datasource.username=${JDBC_DATABASE_USERNAME}
 spring.datasource.password=${JDBC_DATABASE_PASSWORD}
+app.showSwaggerUILink=${SHOW_SWAGGER_UI_LINK:${env.SHOW_SWAGGER_UI_LINK:false}}
 
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQL9Dialect

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -32,4 +32,3 @@ app.startQtrYYYYQ=${START_QTR:${env.START_QTR:20221}}
 app.endQtrYYYYQ=${END_QTR:${env.END_QTR:20222}}
 
 app.ucsb.api.consumer_key=${UCSB_API_KEY:${env.UCSB_API_KEY:see-instructions-in-readme}}
-server.port=${PORT:8080}


### PR DESCRIPTION
Closes #14.

In this PR I implemented the option for developers to enable/disable the swagger ui link in the nav bar. This can be useful to reduce clutter if they are trying to test or demo a (generally frontend) change that does not involve swagger at all. It is set to `true` by default in dev environment and set to `false` by default in prod environment.

With `SHOW_SWAGGER_UI_LINK=true` in the .env or dokku config file, the Swagger UI link appears in the top nav bar:
![image](https://github.com/ucsb-cs156-s24/proj-courses-s24-4pm-3/assets/42985687/e6db06a1-ad31-46d3-bada-e3fd022bd214)

With `SHOW_SWAGGER_UI_LINK=false` in the .env or dokku config file, the link no longer shows up:
![image](https://github.com/ucsb-cs156-s24/proj-courses-s24-4pm-3/assets/42985687/b2e2c825-2328-427e-9bf8-0a729860f95b)


