### PR TITLE
FEATURE: H2 Console option on NavBar

### DIFF
--- a/src/main/resources/application-development.properties
+++ b/src/main/resources/application-development.properties
@@ -4,7 +4,7 @@ spring.datasource.url=jdbc:h2:file:./target/db-development
 spring.datasource.username=sa
 spring.datasource.password=password
 spring.h2.console.settings.web-allow-others=true
-spring.h2.console.enabled=true
+spring.h2.console.enabled=${H2_CONSOLE_ENABLED:${env.H2_CONSOLE_ENABLED:true}}
 app.showSwaggerUILink=true
 
 

--- a/src/main/resources/application-production.properties
+++ b/src/main/resources/application-production.properties
@@ -1,5 +1,6 @@
 spring.datasource.url=${JDBC_DATABASE_URL}
 spring.datasource.username=${JDBC_DATABASE_USERNAME}
 spring.datasource.password=${JDBC_DATABASE_PASSWORD}
+spring.h2.console.enabled=${H2_CONSOLE_ENABLED:${env.H2_CONSOLE_ENABLED:false}}
 
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQL9Dialect


### PR DESCRIPTION
Closes #38.

In this PR I implemented the option for developers to enable/disable the h2 console link in the nav bar. This can be useful to reduce clutter if they are trying to test or demo a (generally frontend) change that does not involve backend at all. It is set to `true` by default in dev environment and set to `false` by default in prod environment.

With `H2_CONSOLE_ENABLED=true` in the .env or dokku config file, the H2 Console link appears in the top nav bar:
![image](https://github.com/ucsb-cs156-s24/proj-courses-s24-4pm-3/assets/42985687/aee9306c-f0a5-4f2e-9988-a160a1f6f2cc)


With `H2_CONSOLE_ENABLED=false` in the .env or dokku config file, the H2 Console link no longer appears:
![image](https://github.com/ucsb-cs156-s24/proj-courses-s24-4pm-3/assets/42985687/237cfbe4-66a6-42ed-a3e1-7ff6dbf708b2)
