### PR TITLE
FEATURE: Added Delete Button to PersonalSchedules page

### DIFF
--- a/frontend/src/main/components/PersonalSections/PersonalSectionsTable.js
+++ b/frontend/src/main/components/PersonalSections/PersonalSectionsTable.js
@@ -1,13 +1,26 @@
 import React from "react";
-import OurTable from "main/components/OurTable";
+import OurTable, { ButtonColumn } from "main/components/OurTable";
+import { useBackendMutation } from "main/utils/useBackend";
 import {
   convertToFraction,
   formatInstructors,
   formatLocation,
   formatTime,
+  cellToAxiosParamsDelete,
+  onDeleteSuccess,
 } from "main/utils/sectionUtils.js";
 
 export default function PersonalSectionsTable({ personalSections }) {
+  const deleteMutation = useBackendMutation(
+    cellToAxiosParamsDelete,
+    { onSuccess: onDeleteSuccess },
+    []
+  );
+
+  const deleteCallback = async (cell) => {
+    deleteMutation.mutate(cell);
+  };
+
   const columns = [
     {
       Header: "Course ID",
@@ -30,7 +43,7 @@ export default function PersonalSectionsTable({ personalSections }) {
       accessor: (row) =>
         convertToFraction(
           row.classSections[0].enrolledTotal,
-          row.classSections[0].maxEnroll,
+          row.classSections[0].maxEnroll
         ),
       id: "enrolled",
     },
@@ -55,15 +68,18 @@ export default function PersonalSectionsTable({ personalSections }) {
     },
   ];
 
-  const testid = "PersonalSectionsTable";
+  const columnsWithDelete = [
+    ...columns,
+    ButtonColumn("Delete", "danger", deleteCallback, "PersonalSectionsTable"),
+  ];
 
-  const columnsToDisplay = columns;
+  const columnsToDisplay = columnsWithDelete;
 
   return (
     <OurTable
       data={personalSections}
       columns={columnsToDisplay}
-      testid={testid}
+      testid={"PersonalSectionsTable"}
     />
   );
 }

--- a/frontend/src/main/utils/sectionUtils.js
+++ b/frontend/src/main/utils/sectionUtils.js
@@ -1,4 +1,20 @@
 import { hhmmTohhmma, convertToTimeRange } from "main/utils/timeUtils.js";
+import { toast } from "react-toastify";
+
+export function onDeleteSuccess(message) {
+  console.log(message);
+  toast(message);
+}
+export function cellToAxiosParamsDelete(cell) {
+  return {
+    url: "/api/courses/user",
+    method: "DELETE",
+    params: {
+      id: cell.row.values.id,
+    },
+  };
+}
+
 
 export const convertToFraction = (en1, en2) => {
   return en1 != null && en2 != null ? `${en1}/${en2}` : "";

--- a/frontend/src/tests/components/PersonalSections/PersonalSectionsTable.test.js
+++ b/frontend/src/tests/components/PersonalSections/PersonalSectionsTable.test.js
@@ -147,4 +147,22 @@ describe("UserTable tests", () => {
       screen.getByTestId(`${testId}-cell-row-2-col-instructor`),
     ).toHaveTextContent("STEPHANSON B, BUCKWALTER J");
   });
+
+  test("renders delete button", () => {
+    const currentUser = currentUserFixtures.userOnly;
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <PersonalSectionsTable
+            personalSections={personalSectionsFixtures.threePersonalSections}
+            currentUser={currentUser}
+          />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    expect(screen.getAllByText("Delete").length).toBeGreaterThan(0);
+  });
+
 });


### PR DESCRIPTION
Before, there was no way to delete a course form your schedule from the personal schedules page. You could only delete a course form the courses page, which was not optimal.

In this PR, I add a column with a delete button for each course under each personal schedule. (note that it doesn't delete the course yet, the button is purely ornamental as of right now.)

<img width="1440" alt="Screenshot 2024-05-26 at 9 02 03 PM" src="https://github.com/ucsb-cs156-s24/proj-courses-s24-4pm-3/assets/38702211/7f605e94-4e25-45d6-ae54-6a1d453b9074">
